### PR TITLE
Remove leading blank lines from HTML pages

### DIFF
--- a/grinding-toronto-alternative.html
+++ b/grinding-toronto-alternative.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/shaft-grinding-toronto.html
+++ b/shaft-grinding-toronto.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/traffic-capture-jamesons.html
+++ b/traffic-capture-jamesons.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Summary
- remove leading blank line so HTML files start with doctype

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688db7676280832eadc3e28acc5aa4d7